### PR TITLE
Improve documentation

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,12 @@
 # 1.0.0
 
 * Updated Queue constructor because bunny 1.1 requires a channel.
+
+# 1.0.1
+
+* Initialized routed_messages to be an Array to avoid nil errors in
+some scenarios.
+
+# 1.0.2
+
+* Improved the readme by focusing on `routed_messages`.

--- a/README.md
+++ b/README.md
@@ -19,38 +19,7 @@ Or install it yourself as:
 
     $ gem install stuffed_bunny
 
-## Usage
-
-### RSpec Example
-
-```ruby
-# spec/spec_helper.rb
-require 'stuffed_bunny'
-
-RSpec.configure do |config|
-
-  config.after(:each) do
-    StuffedBunny.reset!
-  end
-
-end
-```
-
-### Minitest Example
-
-```ruby
-require 'stuffed_bunny'
-
-class MiniTest::Spec
-
-  after :each do
-    StuffedBunny.reset!
-  end
-
-end
-```
-
-### TestUnit Example
+## Example Usage
 
 ```ruby
 require 'stuffed_bunny'

--- a/README.md
+++ b/README.md
@@ -1,15 +1,48 @@
 # StuffedBunny
 
-Provides stubbing of the Bunny gem.
+Provides stubbing of the Bunny gem to faciliate testing.
 
-To faciliate testing, exchanges are represented as a class-level hash. This
-allows all bunny instances access to the same exchanges.
+A `routed_messages` array captures any publised messages on a topic exchange.
+
+## Example Usage
+
+```ruby
+require 'stuffed_bunny' # Bunny is overriden once this is required
+
+class SomeTest < TestUnit::TestCase
+
+  def setup
+    @bunny = Bunny::Client.new
+  end
+
+  def teardown
+    StuffedBunny.reset! # resets the routed_messages
+  end
+
+  def test_that_a_message_is_published_to_an_exchange
+    exchange_options = { } # set it to be a topic exchange, etc.
+    Bunny.run do |b|
+      topic_exchange = b.exchange( "a_topic_exchange", exchange_options)
+      publish_options = { :key => "a.routing.key" }
+      topic_exchange.publish("a message", publish_options)
+    end
+
+    routed_message = @bunny.exchanges["a_topic_exchange"].routed_messages[0]
+    assert_equal "a.routing.key", routed_message.key
+    assert_equal "a message", routed_message.message
+  end
+
+end
+```
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
-    gem 'stuffed_bunny'
+    group :test do
+      # Note that as soon as the gem is required, Bunny is overridden.
+      gem 'stuffed_bunny', :require => false
+    end
 
 And then execute:
 
@@ -18,20 +51,6 @@ And then execute:
 Or install it yourself as:
 
     $ gem install stuffed_bunny
-
-## Example Usage
-
-```ruby
-require 'stuffed_bunny'
-
-class SomeTest < TestUnit::TestCase
-
-  def teardown
-    StuffedBunny.reset!
-  end
-
-end
-```
 
 ## Contributing
 

--- a/lib/stuffed_bunny/bunny_overrides.rb
+++ b/lib/stuffed_bunny/bunny_overrides.rb
@@ -2,8 +2,7 @@ require 'bunny'
 
 # Overriding the Bunny gem's modules and classes.
 #
-# NOTE: Not everything is stubbed yet.  We've only stubbed the method calls we
-# are using in our projects.
+# NOTE: Not everything in Bunny is stubbed here. Pull requests are welcome.
 module Bunny
   def self.run(options = {})
     bunny = Bunny::Client.new(options)
@@ -42,9 +41,9 @@ module Bunny
       @client, @name  = client, name
       @type = options[:type]
     end
-    
+
     def routed_messages
-      @routed_messaged ||= []  
+      @routed_messaged ||= []
     end
 
     # To facilite testing this adds a Struct containing the data
@@ -52,8 +51,8 @@ module Bunny
     #
     # Example usage:
     # Bunny.run do |b|
-    #   topic = b.exchange("some_topic_name", MH::Exchange::OPTIONS)
-    #   options = { :key => "some.routing.key" }.merge(MH::Exchange::PUBLISH_OPTIONS)
+    #   topic = b.exchange("some_topic_name", SOME_EXCHANGE_OPTIONS)
+    #   options = { :key => "some.routing.key" }.merge(SOME_PUBLISH_OPTIONS)
     #   topic.publish("some message", options)
     # end
     #
@@ -70,6 +69,7 @@ module Bunny
   class Queue
     def initialize(channel_or_connection, name = nil, opts = {})
     end
+
     def delete(*args)
       :delete_ok
     end

--- a/lib/stuffed_bunny/version.rb
+++ b/lib/stuffed_bunny/version.rb
@@ -1,3 +1,3 @@
 module StuffedBunny
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end


### PR DESCRIPTION
This primarily improves the example usage in the readme.  It was unclear how to use this gem for testing before: no explanation of `routed_messages`, etc..