### PR TITLE
Lock bunny at v1.4.1

### DIFF
--- a/lib/stuffed_bunny/version.rb
+++ b/lib/stuffed_bunny/version.rb
@@ -1,3 +1,3 @@
 module StuffedBunny
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/stuffed_bunny.gemspec
+++ b/stuffed_bunny.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_development_dependency 'bunny', '~> 0.8'
+  gem.add_development_dependency 'bunny', '~> 0.8', '<= 1.4.1'
   gem.add_development_dependency 'rake'
 end


### PR DESCRIPTION
This lock bunny down to versions <= 1.4.1
* Support for newer versions will require updating this gem to support
them. See issue #6.
* Tests only pass when run in Ruby 1.9.3. That's something else to fix
as well. Opened issue #7.
* Bumps this to version 1.0.3.